### PR TITLE
explicit require "forwardable"

### DIFF
--- a/lib/pastel/delegator.rb
+++ b/lib/pastel/delegator.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+require 'forwardable'
+
 module Pastel
   # Wrapes the {DecoratorChain} to allow for easy resolution
   # of string coloring.


### PR DESCRIPTION
I was having trouble using the gem in irb:

``` ruby
ree-1.8.7-2012.02 :003 > require 'pastel'
NameError: uninitialized constant Pastel::Delegator::Forwardable
```

 The issue was that the "forwardable" library was to be explicitly required. This commit fix the issue :)

Thanks for the gem!

Andrea
