### PR TITLE
Require StringScanner since it is a dependency 

### DIFF
--- a/lib/pastel.rb
+++ b/lib/pastel.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require "strscan"
+
 require 'tty-color'
 
 require_relative 'pastel/alias_importer'


### PR DESCRIPTION
### Describe the change
Resolves the following issue:
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/5059927/69000232-6292e000-089a-11ea-9a75-0551e846b694.png">

### Why are we doing this?
To prevent an error from being raised when using #undecorate.

### Benefits
Errors won't be raised without manually require dependencies. 

### Drawbacks
None, that I am aware of.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
