### PR TITLE
Make `Pastel#strip` recognise no-colour sequence of "\e[m" produces by some standard programs

### DIFF
--- a/lib/pastel/color.rb
+++ b/lib/pastel/color.rb
@@ -14,7 +14,7 @@ module Pastel
     ALIASES = {}
 
     # Match all color escape sequences
-    ANSI_COLOR_REGEXP = /\x1b+(\[|\[\[)[0-9;:?]+m/mo.freeze
+    ANSI_COLOR_REGEXP = /\x1b+(\[|\[\[)[0-9;:?]*m/mo.freeze
 
     attr_reader :enabled
     alias enabled? enabled

--- a/spec/unit/color/strip_spec.rb
+++ b/spec/unit/color/strip_spec.rb
@@ -53,4 +53,9 @@ RSpec.describe Pastel::Color, '.strip' do
     string = "This is a \e[1m\e[34mbold blue text\e[0m"
     expect(color.strip(string)).to eq("This is a bold blue text")
   end
+
+  it 'strips "\e[m" no-color code produced by some standard programs ' do
+    string = "\e[?1h\e=\r\e[33m438b059\e[m Change to bump version up\e[m\r\n\r\e[K\e[?1l\e>"
+    expect(color.strip(string)).to eq("\e[?1h\e=\r438b059 Change to bump version up\r\n\r\e[K\e[?1l\e>")
+  end
 end


### PR DESCRIPTION
### Describe the change

Make `Pastel#strip` strip no-colour sequence of `\e[m` produces by some standard programs (including `git`)

### Why are we doing this?

For some reason which I still didn't investigate `git` produces a no-colour sequence of `\e[m` instead of `\e[0m`.
Proof: if you type `git log -1 --oneline` right in this repo, you will get
`"\e[?1h\e=\r\e[33m438b059\e[m Change to bump version up\e[m\r\n\r\e[K\e[?1l\e>"` as an output (see `\e[m` occured twice here).

`Pastel#strip` is often used to decolorize output of programs, normally for testing or parsing purposes. I have stumbled on this issue while applying `Pastel#strip` to `git` output.

### Benefits

`Pastel#strip` will be able to be used against output of standard programs like `git`

### Drawbacks

**Important!** The change of `ANSI_COLOR_REGEXP` regexp might lead to unintended consequences, another pair of eyes is needed to be sure this change is safe.

### Requirements

Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[n/a] Documentation updated?
